### PR TITLE
Account for time fluctuation

### DIFF
--- a/src/balance/balance.controller.e2e-spec.ts
+++ b/src/balance/balance.controller.e2e-spec.ts
@@ -59,23 +59,27 @@ describe('E2E: BalanceController', () => {
   });
 
   it('Adds payments: /balance/:id/reward (PUT)', async () => {
-    await request(app.getHttpServer()).put(`/balance/${userId}/reward`).send({
-      amount: 500,
-      payer: 'NestJS',
-      timestampMS: Date.now() - ONE_DAY
-    });
+    await request(app.getHttpServer())
+      .put(`/balance/${userId}/reward`)
+      .send({
+        amount: 500,
+        payer: 'NestJS',
+        timestampMS: Date.now() - ONE_DAY,
+      });
 
     await request(app.getHttpServer()).put(`/balance/${userId}/reward`).send({
       amount: 200,
       payer: 'NodeJS',
-      timestampMS: Date.now()
+      timestampMS: Date.now(),
     });
 
-    await request(app.getHttpServer()).put(`/balance/${userId}/reward`).send({
-      amount: 200,
-      payer: 'NodeJS',
-      timestampMS: Date.now() - 1000
-    });
+    await request(app.getHttpServer())
+      .put(`/balance/${userId}/reward`)
+      .send({
+        amount: 200,
+        payer: 'NodeJS',
+        timestampMS: Date.now() - 1000,
+      });
 
     return request(app.getHttpServer())
       .get(`/balance/${userId}`)
@@ -94,18 +98,19 @@ describe('E2E: BalanceController', () => {
   });
 
   it('Returns an aggregated ledger: /balance/:id/payer-balances', async () => {
-
     await request(app.getHttpServer())
       .get(`/balance/${userId}/payer-balances`)
       .expect(200)
-      .then(({body}) => {
-        expect(body).toEqual(expect.objectContaining({
-          promotionalPoints: 1000,
-          NodeJS: 400,
-          NestJS: 500,
-        }))
-      })
-  })
+      .then(({ body }) => {
+        expect(body).toEqual(
+          expect.objectContaining({
+            promotionalPoints: 1000,
+            NodeJS: 400,
+            NestJS: 500,
+          }),
+        );
+      });
+  });
 
   it('Handles payments higher than the available balance: /balance/:id/pay (PUT)', async () => {
     return request(app.getHttpServer())

--- a/src/balance/balance.controller.e2e-spec.ts
+++ b/src/balance/balance.controller.e2e-spec.ts
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 import { DefaultValidationPipeOptions } from '../main.types';
 import { UserModule } from '../user/user.module';
 import { BalanceModule } from './balance.module';
-
+const ONE_DAY = 1000 * 60 * 60 * 24;
 describe('E2E: BalanceController', () => {
   let app: INestApplication;
   beforeEach(async () => {
@@ -60,15 +60,15 @@ describe('E2E: BalanceController', () => {
 
   it('Adds payments: /balance/:id/reward (PUT)', async () => {
     await request(app.getHttpServer()).put(`/balance/${userId}/reward`).send({
-      userId,
       amount: 500,
       payer: 'NestJS',
+      timestampMS: Date.now() - ONE_DAY
     });
 
     await request(app.getHttpServer()).put(`/balance/${userId}/reward`).send({
-      userId,
       amount: 200,
       payer: 'NodeJS',
+      timestampMS: Date.now()
     });
 
     return request(app.getHttpServer())

--- a/src/balance/balance.controller.e2e-spec.ts
+++ b/src/balance/balance.controller.e2e-spec.ts
@@ -71,10 +71,16 @@ describe('E2E: BalanceController', () => {
       timestampMS: Date.now()
     });
 
+    await request(app.getHttpServer()).put(`/balance/${userId}/reward`).send({
+      amount: 200,
+      payer: 'NodeJS',
+      timestampMS: Date.now() - 1000
+    });
+
     return request(app.getHttpServer())
       .get(`/balance/${userId}`)
       .then(({ text }) => {
-        expect(parseInt(text, 10)).toEqual(1700);
+        expect(parseInt(text, 10)).toEqual(1900);
       });
   });
 
@@ -83,9 +89,23 @@ describe('E2E: BalanceController', () => {
       .get(`/balance/${userId}/detailed`)
       .expect(200)
       .then(({ body }) => {
-        expect(body).toHaveLength(3);
+        expect(body).toHaveLength(4);
       });
   });
+
+  it('Returns an aggregated ledger: /balance/:id/payer-balances', async () => {
+
+    await request(app.getHttpServer())
+      .get(`/balance/${userId}/payer-balances`)
+      .expect(200)
+      .then(({body}) => {
+        expect(body).toEqual(expect.objectContaining({
+          promotionalPoints: 1000,
+          NodeJS: 400,
+          NestJS: 500,
+        }))
+      })
+  })
 
   it('Handles payments higher than the available balance: /balance/:id/pay (PUT)', async () => {
     return request(app.getHttpServer())
@@ -102,7 +122,7 @@ describe('E2E: BalanceController', () => {
     return request(app.getHttpServer())
       .get(`/balance/${userId}`)
       .then(({ text }) => {
-        expect(parseInt(text, 10)).toEqual(600);
+        expect(parseInt(text, 10)).toEqual(800);
       });
   });
 
@@ -111,7 +131,7 @@ describe('E2E: BalanceController', () => {
       .get(`/balance/${userId}/detailed`)
       .expect(200)
       .then(({ body }) => {
-        expect(body).toHaveLength(2);
+        expect(body).toHaveLength(3);
       });
   });
 

--- a/src/balance/balance.controller.ts
+++ b/src/balance/balance.controller.ts
@@ -55,8 +55,7 @@ export class BalanceController {
     summary: 'Get the detailed ledger for a user with the passed userId',
   })
   @ApiOkResponse({
-    description:
-      'Return an array of each individual record in the ledger',
+    description: 'Return an array of each individual record in the ledger',
   })
   @ApiNotFoundResponse({
     description: 'No user with this ID was found, or the ledger is empty',
@@ -77,11 +76,11 @@ export class BalanceController {
   }
 
   @ApiOperation({
-    summary: 'Get the total number of points for each payer, in the users ledger',
+    summary:
+      'Get the total number of points for each payer, in the users ledger',
   })
   @ApiOkResponse({
-    description:
-      'Returns an array of unique payers, with their total balance',
+    description: 'Returns an array of unique payers, with their total balance',
   })
   @ApiNotFoundResponse({
     description: 'No user with this ID was found, or the ledger is empty',
@@ -90,9 +89,7 @@ export class BalanceController {
     description: 'The passed ID is not a valid UUID',
   })
   @Get(':userId/payer-balances')
-  public async payerBalances(
-    @Param('userId', ParseUUIDPipe) userId: string,
-  ) {
+  public async payerBalances(@Param('userId', ParseUUIDPipe) userId: string) {
     return this.balanceService.aggregateUserLedger(userId);
   }
 
@@ -102,7 +99,8 @@ export class BalanceController {
     are used first`,
   })
   @ApiOkResponse({
-    description: 'An array of the payers involved in the transaction, and their deducted amounts',
+    description:
+      'An array of the payers involved in the transaction, and their deducted amounts',
   })
   @ApiNotFoundResponse({
     description: 'No user with this ID was found',

--- a/src/balance/balance.controller.ts
+++ b/src/balance/balance.controller.ts
@@ -81,8 +81,8 @@ export class BalanceController {
     description: `This will reduce the number of available points in a user\'s ledger. The oldest records in the ledger
     are used first`,
   })
-  @ApiNoContentResponse({
-    description: 'Returns an OK, signifying that reduction was successful',
+  @ApiOkResponse({
+    description: 'An array of the payers involved in the transaction, and their deducted amounts',
   })
   @ApiNotFoundResponse({
     description: 'No user with this ID was found',
@@ -92,7 +92,6 @@ export class BalanceController {
       'The user with the corresponding id does not have enough points to complete the payment, or the UUID passed failed to validate',
   })
   @Put(':userId/pay')
-  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiParam({
     name: 'userId',
     type: 'string',

--- a/src/balance/balance.controller.ts
+++ b/src/balance/balance.controller.ts
@@ -56,7 +56,7 @@ export class BalanceController {
   })
   @ApiOkResponse({
     description:
-      'Return a number, representing the current balance for the user',
+      'Return an array of each individual record in the ledger',
   })
   @ApiNotFoundResponse({
     description: 'No user with this ID was found, or the ledger is empty',
@@ -74,6 +74,26 @@ export class BalanceController {
     @Param('userId', ParseUUIDPipe) userId: string,
   ) {
     return this.balanceService.userLedger(userId);
+  }
+
+  @ApiOperation({
+    summary: 'Get the total number of points for each payer, in the users ledger',
+  })
+  @ApiOkResponse({
+    description:
+      'Returns an array of unique payers, with their total balance',
+  })
+  @ApiNotFoundResponse({
+    description: 'No user with this ID was found, or the ledger is empty',
+  })
+  @ApiBadRequestResponse({
+    description: 'The passed ID is not a valid UUID',
+  })
+  @Get(':userId/payer-balances')
+  public async payerBalances(
+    @Param('userId', ParseUUIDPipe) userId: string,
+  ) {
+    return this.balanceService.aggregateUserLedger(userId);
   }
 
   @ApiOperation({

--- a/src/balance/balance.module.ts
+++ b/src/balance/balance.module.ts
@@ -1,12 +1,16 @@
 import { Module } from '@nestjs/common';
-import {LedgerRepositoryModule} from '../common/repository/ledger/ledger-repository.module';
+import { LedgerRepositoryModule } from '../common/repository/ledger/ledger-repository.module';
 import { PaymentRepositoryModule } from '../common/repository/payment/payment-repository.module';
 import { UserRepositoryModule } from '../common/repository/user/user-repository.module';
 import { BalanceController } from './balance.controller';
 import { BalanceService } from './balance.service';
 
 @Module({
-  imports: [UserRepositoryModule, PaymentRepositoryModule, LedgerRepositoryModule],
+  imports: [
+    UserRepositoryModule,
+    PaymentRepositoryModule,
+    LedgerRepositoryModule,
+  ],
   controllers: [BalanceController],
   providers: [BalanceService],
 })

--- a/src/balance/balance.module.ts
+++ b/src/balance/balance.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import {LedgerRepositoryModule} from '../common/repository/ledger/ledger-repository.module';
 import { PaymentRepositoryModule } from '../common/repository/payment/payment-repository.module';
 import { UserRepositoryModule } from '../common/repository/user/user-repository.module';
 import { BalanceController } from './balance.controller';
 import { BalanceService } from './balance.service';
 
 @Module({
-  imports: [UserRepositoryModule, PaymentRepositoryModule],
+  imports: [UserRepositoryModule, PaymentRepositoryModule, LedgerRepositoryModule],
   controllers: [BalanceController],
   providers: [BalanceService],
 })

--- a/src/balance/balance.service.spec.ts
+++ b/src/balance/balance.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, mockClear } from 'jest-mock-extended';
-import {LedgerRepository} from '../common/repository/ledger/ledger-repository.provider';
+import { LedgerRepository } from '../common/repository/ledger/ledger-repository.provider';
 import { PaymentRepository } from '../common/repository/payment/payment-repository.provider';
 import { UserRepository } from '../common/repository/user/user-repository.provider';
 import { BalanceService } from './balance.service';
@@ -28,12 +28,13 @@ describe('BalanceService', () => {
     update: jest.fn(),
   });
   const mockLedger = {
-    userId: mockUser.id, paymentId: 'mockPaymentId'
+    userId: mockUser.id,
+    paymentId: 'mockPaymentId',
   };
 
   const mockLedgerRepository = mock<LedgerRepository>({
-    findById: jest.fn().mockResolvedValue(mockLedger)
-  })
+    findById: jest.fn().mockResolvedValue(mockLedger),
+  });
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -49,7 +50,7 @@ describe('BalanceService', () => {
         {
           provide: LedgerRepository,
           useValue: mockLedgerRepository,
-        }
+        },
       ],
     }).compile();
 
@@ -87,7 +88,7 @@ describe('BalanceService', () => {
       const mockPayment = {
         payer: 'TestPayer',
         amount: 1000,
-        timestampMS: 1
+        timestampMS: 1,
       };
       await service.increaseBalance('mocked', mockPayment);
 
@@ -100,7 +101,10 @@ describe('BalanceService', () => {
 
   describe('reduceBalance()', () => {
     it('throws an error when the user is not found', async () => {
-      mockLedgerRepository.findById.mockResolvedValueOnce({ userId: null, paymentId: null })
+      mockLedgerRepository.findById.mockResolvedValueOnce({
+        userId: null,
+        paymentId: null,
+      });
       await expect(service.reduceBalance('notFound', 500)).rejects.toEqual(
         expect.objectContaining({
           message: 'Not Found',
@@ -119,10 +123,13 @@ describe('BalanceService', () => {
         mockLedger.paymentId,
         { ...mockPayer, amount: 0 },
       );
-      expect(mockUserRepository.update).toHaveBeenCalledWith(mockLedger.userId, {
-        ...mockUser,
-        points: 500,
-      });
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        mockLedger.userId,
+        {
+          ...mockUser,
+          points: 500,
+        },
+      );
     });
 
     it('reduces the user balance using a payer with more than enough points', async () => {
@@ -135,10 +142,13 @@ describe('BalanceService', () => {
         mockLedger.paymentId,
         { ...mockPayer, amount: 250 },
       );
-      expect(mockUserRepository.update).toHaveBeenCalledWith(mockLedger.userId, {
-        ...mockUser,
-        points: 750,
-      });
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        mockLedger.userId,
+        {
+          ...mockUser,
+          points: 750,
+        },
+      );
     });
   });
 });

--- a/src/balance/balance.service.ts
+++ b/src/balance/balance.service.ts
@@ -1,14 +1,15 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import {LedgerRepository} from '../common/repository/ledger/ledger-repository.provider';
 import { PaymentRepository } from '../common/repository/payment/payment-repository.provider';
 import { RewardDto } from '../common/repository/payment/payment.dto';
 import { UserRepository } from '../common/repository/user/user-repository.provider';
-import { v4 as uuid } from 'uuid';
 
 @Injectable()
 export class BalanceService {
   constructor(
     private readonly paymentRepository: PaymentRepository,
     private readonly userRepository: UserRepository,
+    private readonly ledgerRepository: LedgerRepository,
   ) {}
 
   async userBalance(userId: string) {
@@ -22,18 +23,20 @@ export class BalanceService {
   }
 
   async userLedger(userId: string) {
-    const ledger = await this.paymentRepository.findById(userId);
-    if (ledger.length === 0) {
+    const { paymentId } = await this.ledgerRepository.findById(userId);
+    const payment = await this.paymentRepository.findById(paymentId);
+    if (payment.length === 0) {
       throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
     }
-    return ledger;
+    return payment;
   }
 
-  async reduceBalance(userId: uuid, amount: number) {
-    const user = await this.userRepository.findById(userId);
-    if (!user) {
+  async reduceBalance(id: string, amount: number) {
+    const { userId, paymentId } = await this.ledgerRepository.findById(id);
+    if (!userId) {
       throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
     }
+    const user = await this.userRepository.findById(userId);
     if (user.points < amount) {
       throw new HttpException(
         `${userId} lacks sufficient points`,
@@ -43,7 +46,7 @@ export class BalanceService {
     let currentAmountDeducted = 0;
     while (currentAmountDeducted < amount) {
       const remainingPayment = amount - currentAmountDeducted;
-      const currentPayer = await this.paymentRepository.getCurrentPayer(userId);
+      const currentPayer = await this.paymentRepository.getCurrentPayer(paymentId);
       const deduction =
         currentPayer.amount <= remainingPayment
           ? currentPayer.amount
@@ -53,7 +56,7 @@ export class BalanceService {
         ...currentPayer,
         amount: currentPayer.amount - deduction,
       };
-      await this.paymentRepository.updateCurrentPayer(userId, updatedPayer);
+      await this.paymentRepository.updateCurrentPayer(paymentId, updatedPayer);
     }
     await this.userRepository.update(userId, {
       ...user,
@@ -61,10 +64,11 @@ export class BalanceService {
     });
   }
 
-  async increaseBalance(userId: uuid, payment: RewardDto) {
+  async increaseBalance(id: string, payment: RewardDto) {
+    const { userId, paymentId } = await this.ledgerRepository.findById(id);
     const user = await this.userRepository.findById(userId);
     await Promise.all([
-      this.paymentRepository.insert([{ userId, ...payment }]),
+      this.paymentRepository.update(paymentId, payment),
       this.userRepository.update(userId, {
         ...user,
         points: user.points + payment.amount,

--- a/src/balance/balance.service.ts
+++ b/src/balance/balance.service.ts
@@ -31,6 +31,19 @@ export class BalanceService {
     return payment;
   }
 
+  async aggregateUserLedger(userId: string) {
+    const ledger = await this.userLedger(userId);
+    const aggregates: { [key:string]: number } = {};
+    ledger.forEach(l => {
+      if(aggregates[l.payer]) {
+        aggregates[l.payer] += l.amount
+      } else {
+        aggregates[l.payer] = l.amount
+      }
+    })
+    return aggregates;
+  }
+
   async reduceBalance(id: string, amount: number): Promise<Array<PaymentResponseDto>> {
     const { userId, paymentId } = await this.ledgerRepository.findById(id);
     if (!userId) {

--- a/src/common/repository/ledger/ledger-repository.module.ts
+++ b/src/common/repository/ledger/ledger-repository.module.ts
@@ -1,6 +1,6 @@
-import {Module} from '@nestjs/common';
-import {StoreModule} from '../../store/store.module';
-import {LedgerRepository} from './ledger-repository.provider';
+import { Module } from '@nestjs/common';
+import { StoreModule } from '../../store/store.module';
+import { LedgerRepository } from './ledger-repository.provider';
 
 @Module({
   imports: [StoreModule],

--- a/src/common/repository/ledger/ledger-repository.module.ts
+++ b/src/common/repository/ledger/ledger-repository.module.ts
@@ -1,0 +1,10 @@
+import {Module} from '@nestjs/common';
+import {StoreModule} from '../../store/store.module';
+import {LedgerRepository} from './ledger-repository.provider';
+
+@Module({
+  imports: [StoreModule],
+  providers: [LedgerRepository],
+  exports: [LedgerRepository],
+})
+export class LedgerRepositoryModule {}

--- a/src/common/repository/ledger/ledger-repository.provider.ts
+++ b/src/common/repository/ledger/ledger-repository.provider.ts
@@ -1,0 +1,40 @@
+import {Injectable} from '@nestjs/common';
+import {RedisStore} from '../../store/redis-store';
+import {IRepository} from '../../store/store.types';
+import {LedgerDto} from './ledger.dto';
+
+@Injectable()
+export class LedgerRepository implements IRepository<LedgerDto> {
+  public readonly keyPrefix = 'ledger';
+  constructor(private readonly dataStore: RedisStore) {}
+
+  async delete(id: string): Promise<boolean> {
+    const { userId } = await this.findById(id);
+    if(!userId) {
+      return false;
+    }
+    await this.dataStore.client.del(this.generateKey(id));
+
+    return true;
+  }
+
+  async findById(id: string): Promise<LedgerDto> {
+    const { paymentId, userId, } = await this.dataStore.client.hgetall(this.generateKey(id));
+    return {
+      paymentId,
+      userId,
+    };
+  }
+
+  async insert(entity: LedgerDto): Promise<boolean> {
+    const { userId } = entity;
+
+    await this.dataStore.client.hset(this.generateKey(userId), { ...entity });
+
+    return true;
+  }
+
+  private generateKey(k: string): string {
+    return `${this.keyPrefix}:${k}`
+  }
+}

--- a/src/common/repository/ledger/ledger-repository.provider.ts
+++ b/src/common/repository/ledger/ledger-repository.provider.ts
@@ -1,7 +1,7 @@
-import {Injectable} from '@nestjs/common';
-import {RedisStore} from '../../store/redis-store';
-import {IRepository} from '../../store/store.types';
-import {LedgerDto} from './ledger.dto';
+import { Injectable } from '@nestjs/common';
+import { RedisStore } from '../../store/redis-store';
+import { IRepository } from '../../store/store.types';
+import { LedgerDto } from './ledger.dto';
 
 @Injectable()
 export class LedgerRepository implements IRepository<LedgerDto> {
@@ -10,7 +10,7 @@ export class LedgerRepository implements IRepository<LedgerDto> {
 
   async delete(id: string): Promise<boolean> {
     const { userId } = await this.findById(id);
-    if(!userId) {
+    if (!userId) {
       return false;
     }
     await this.dataStore.client.del(this.generateKey(id));
@@ -19,7 +19,9 @@ export class LedgerRepository implements IRepository<LedgerDto> {
   }
 
   async findById(id: string): Promise<LedgerDto> {
-    const { paymentId, userId, } = await this.dataStore.client.hgetall(this.generateKey(id));
+    const { paymentId, userId } = await this.dataStore.client.hgetall(
+      this.generateKey(id),
+    );
     return {
       paymentId,
       userId,
@@ -35,6 +37,6 @@ export class LedgerRepository implements IRepository<LedgerDto> {
   }
 
   private generateKey(k: string): string {
-    return `${this.keyPrefix}:${k}`
+    return `${this.keyPrefix}:${k}`;
   }
 }

--- a/src/common/repository/ledger/ledger.dto.ts
+++ b/src/common/repository/ledger/ledger.dto.ts
@@ -1,0 +1,5 @@
+
+export class LedgerDto {
+  userId: string;
+  paymentId: string;
+}

--- a/src/common/repository/ledger/ledger.dto.ts
+++ b/src/common/repository/ledger/ledger.dto.ts
@@ -1,4 +1,3 @@
-
 export class LedgerDto {
   userId: string;
   paymentId: string;

--- a/src/common/repository/payment/payment-repository.provider.ts
+++ b/src/common/repository/payment/payment-repository.provider.ts
@@ -5,7 +5,9 @@ import { IRepository } from '../../store/store.types';
 import { RewardDto, PaymentDto } from './payment.dto';
 
 @Injectable()
-export class PaymentRepository implements IRepository<RewardDto | Array<RewardDto>> {
+export class PaymentRepository
+  implements IRepository<RewardDto | Array<RewardDto>>
+{
   public readonly keyPrefix = 'payment';
   constructor(private readonly dataStore: RedisStore) {}
 
@@ -19,8 +21,8 @@ export class PaymentRepository implements IRepository<RewardDto | Array<RewardDt
   }
 
   async updateCurrentPayer(id: string, payment: PaymentDto): Promise<boolean> {
-    const entry = await this.dataStore.client.zpopmin(this.generateKey(id), 1)
-    if(payment.amount > 0) {
+    const entry = await this.dataStore.client.zpopmin(this.generateKey(id), 1);
+    if (payment.amount > 0) {
       const newEntry = JSON.parse(entry[0]) as RewardDto;
       await this.dataStore.client.zadd(
         this.generateKey(id),
@@ -43,7 +45,7 @@ export class PaymentRepository implements IRepository<RewardDto | Array<RewardDt
       0,
       -1,
     );
-    return ledger.map(x => JSON.parse(x) as RewardDto);
+    return ledger.map((x) => JSON.parse(x) as RewardDto);
   }
 
   async insert(entity: RewardDto): Promise<string> {
@@ -55,7 +57,7 @@ export class PaymentRepository implements IRepository<RewardDto | Array<RewardDt
     await this.dataStore.client.zadd(
       this.generateKey(id),
       entity.timestampMS,
-      JSON.stringify({ ...entity, receivedTs: Date.now()}),
+      JSON.stringify({ ...entity, receivedTs: Date.now() }),
     );
     return id;
   }

--- a/src/common/repository/payment/payment.dto.ts
+++ b/src/common/repository/payment/payment.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsString, IsUUID } from 'class-validator';
+import {ApiProperty} from '@nestjs/swagger';
+import { IsNumber, IsString } from 'class-validator';
 
 export class PaymentDto {
   @ApiProperty()
@@ -9,12 +9,16 @@ export class PaymentDto {
 
 export class RewardDto extends PaymentDto {
   @ApiProperty()
-  @IsUUID()
-  userId: string;
-
-  @ApiProperty()
   @IsString()
   payer: string;
+
+  @ApiProperty({
+    description: 'The number of milliseconds since the start of the Unix epoch'
+  })
+  @IsNumber()
+  timestampMS: number;
+
+  receivedTs?: number;
 }
 
 export type Ledger = Array<RewardDto>;

--- a/src/common/repository/payment/payment.dto.ts
+++ b/src/common/repository/payment/payment.dto.ts
@@ -1,4 +1,4 @@
-import {ApiProperty, PickType} from '@nestjs/swagger';
+import { ApiProperty, PickType } from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
 
 export class PaymentDto {
@@ -13,7 +13,7 @@ export class RewardDto extends PaymentDto {
   payer: string;
 
   @ApiProperty({
-    description: 'The number of milliseconds since the start of the Unix epoch'
+    description: 'The number of milliseconds since the start of the Unix epoch',
   })
   @IsNumber()
   timestampMS: number;

--- a/src/common/repository/payment/payment.dto.ts
+++ b/src/common/repository/payment/payment.dto.ts
@@ -1,4 +1,4 @@
-import {ApiProperty} from '@nestjs/swagger';
+import {ApiProperty, PickType} from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
 
 export class PaymentDto {
@@ -21,4 +21,7 @@ export class RewardDto extends PaymentDto {
   receivedTs?: number;
 }
 
-export type Ledger = Array<RewardDto>;
+export class PaymentResponseDto extends PickType(RewardDto, ['payer']) {
+  deduction: number;
+  balance: number;
+}

--- a/src/common/repository/user/user-repository.provider.ts
+++ b/src/common/repository/user/user-repository.provider.ts
@@ -38,7 +38,12 @@ export class UserRepository implements IRepository<UserDto> {
     const id = uuid();
     await Promise.all([
       this.dataStore.client.sadd(this.keyPrefix, id),
-      this.dataStore.client.hset(this.generateKey(id), { firstName, lastName, points, id }),
+      this.dataStore.client.hset(this.generateKey(id), {
+        firstName,
+        lastName,
+        points,
+        id,
+      }),
     ]);
 
     return id;
@@ -54,7 +59,10 @@ export class UserRepository implements IRepository<UserDto> {
   async update(id: string, entity: UpdateUserDto): Promise<boolean> {
     const current = await this.dataStore.client.hgetall(this.generateKey(id));
     const merged = { ...current, ...entity };
-    const numUpdated = await this.dataStore.client.hset(this.generateKey(id), merged);
+    const numUpdated = await this.dataStore.client.hset(
+      this.generateKey(id),
+      merged,
+    );
     return numUpdated > 0;
   }
 
@@ -68,6 +76,6 @@ export class UserRepository implements IRepository<UserDto> {
   }
 
   private generateKey(k: string): string {
-    return `${this.keyPrefix}:${k}`
+    return `${this.keyPrefix}:${k}`;
   }
 }

--- a/src/common/store/store.types.ts
+++ b/src/common/store/store.types.ts
@@ -1,4 +1,5 @@
 export interface IRepository<T> {
+  keyPrefix: string;
   findById: (id: string) => Promise<T>;
   insert: (entity: T, echoId?: boolean) => Promise<boolean | string>;
   delete: (id: string) => Promise<boolean>;

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import {LedgerRepositoryModule} from '../common/repository/ledger/ledger-repository.module';
+import { LedgerRepositoryModule } from '../common/repository/ledger/ledger-repository.module';
 import { PaymentRepositoryModule } from '../common/repository/payment/payment-repository.module';
 import { UserRepositoryModule } from '../common/repository/user/user-repository.module';
 import { StoreModule } from '../common/store/store.module';
@@ -7,7 +7,12 @@ import { UserService } from './user.service';
 import { UserController } from './user.controller';
 
 @Module({
-  imports: [StoreModule, UserRepositoryModule, PaymentRepositoryModule, LedgerRepositoryModule],
+  imports: [
+    StoreModule,
+    UserRepositoryModule,
+    PaymentRepositoryModule,
+    LedgerRepositoryModule,
+  ],
   providers: [UserService],
   controllers: [UserController],
 })

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import {LedgerRepositoryModule} from '../common/repository/ledger/ledger-repository.module';
 import { PaymentRepositoryModule } from '../common/repository/payment/payment-repository.module';
 import { UserRepositoryModule } from '../common/repository/user/user-repository.module';
 import { StoreModule } from '../common/store/store.module';
@@ -6,7 +7,7 @@ import { UserService } from './user.service';
 import { UserController } from './user.controller';
 
 @Module({
-  imports: [StoreModule, UserRepositoryModule, PaymentRepositoryModule],
+  imports: [StoreModule, UserRepositoryModule, PaymentRepositoryModule, LedgerRepositoryModule],
   providers: [UserService],
   controllers: [UserController],
 })

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, mockClear } from 'jest-mock-extended';
-import {LedgerRepository} from '../common/repository/ledger/ledger-repository.provider';
+import { LedgerRepository } from '../common/repository/ledger/ledger-repository.provider';
 import { PaymentRepository } from '../common/repository/payment/payment-repository.provider';
 import { UserRepository } from '../common/repository/user/user-repository.provider';
 import { UserDto } from '../common/repository/user/user.dto';
@@ -36,7 +36,7 @@ describe('UserService', () => {
         {
           provide: LedgerRepository,
           useValue: mockLedgerRepository,
-        }
+        },
       ],
     }).compile();
 
@@ -62,13 +62,11 @@ describe('UserService', () => {
         expect.objectContaining({ ...mockUser, points: 1000 }),
       );
       expect(mockPaymentRepository.insert).toHaveBeenCalledWith(
-        expect.objectContaining(
-          {
-            amount: 1000,
-            payer: 'promotionalPoints',
-            timestampMS: 1,
-          },
-        ),
+        expect.objectContaining({
+          amount: 1000,
+          payer: 'promotionalPoints',
+          timestampMS: 1,
+        }),
       );
     });
   });

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock, mockClear } from 'jest-mock-extended';
+import {LedgerRepository} from '../common/repository/ledger/ledger-repository.provider';
 import { PaymentRepository } from '../common/repository/payment/payment-repository.provider';
 import { UserRepository } from '../common/repository/user/user-repository.provider';
 import { UserDto } from '../common/repository/user/user.dto';
@@ -19,6 +20,7 @@ describe('UserService', () => {
     update: jest.fn(),
   });
   const mockPaymentRepository = mock<PaymentRepository>();
+  const mockLedgerRepository = mock<LedgerRepository>();
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -31,6 +33,10 @@ describe('UserService', () => {
           provide: PaymentRepository,
           useValue: mockPaymentRepository,
         },
+        {
+          provide: LedgerRepository,
+          useValue: mockLedgerRepository,
+        }
       ],
     }).compile();
 
@@ -56,13 +62,13 @@ describe('UserService', () => {
         expect.objectContaining({ ...mockUser, points: 1000 }),
       );
       expect(mockPaymentRepository.insert).toHaveBeenCalledWith(
-        expect.objectContaining([
+        expect.objectContaining(
           {
-            userId: 'mockId',
             amount: 1000,
-            payer: 'Fetch Rewards',
+            payer: 'promotionalPoints',
+            timestampMS: 1,
           },
-        ]),
+        ),
       );
     });
   });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,5 +1,5 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import {LedgerRepository} from '../common/repository/ledger/ledger-repository.provider';
+import { LedgerRepository } from '../common/repository/ledger/ledger-repository.provider';
 import { PaymentRepository } from '../common/repository/payment/payment-repository.provider';
 import { UserRepository } from '../common/repository/user/user-repository.provider';
 import { UpdateUserDto, UserDto } from '../common/repository/user/user.dto';
@@ -14,13 +14,11 @@ export class UserService {
 
   public async addUser(user: UpdateUserDto): Promise<string> {
     const userId = await this.userRepository.insert(user);
-    const paymentId = await this.paymentRepository.insert(
-      {
-        amount: user.points,
-        payer: 'promotionalPoints',
-        timestampMS: 1, // Set to basically the beginning of the unix epoch.  Spend promo points right away.  Alternatively, set to the max of the epoch to keep the "cost" off of the books
-      },
-    );
+    const paymentId = await this.paymentRepository.insert({
+      amount: user.points,
+      payer: 'promotionalPoints',
+      timestampMS: 1, // Set to basically the beginning of the unix epoch.  Spend promo points right away.  Alternatively, set to the max of the epoch to keep the "cost" off of the books
+    });
     await this.ledgerRepository.insert({ userId, paymentId });
     return userId;
   }


### PR DESCRIPTION
![gif](https://media.giphy.com/media/WqEgLKUahHsXY8Wp97/giphy.gif)

When reviewing the product requirements, it was discovered that it was necessary to execute payments based on a timestamp that was passed to the API, rather than relying on the arrival time of the the reward object.  The two concepts require using different redis data structures to achieve this. In the case of arrival time, using redis lists as a queue was ideal.  Now, because we're relying on an arbitrary time stamp, we need a way to quickly treat the payments as sorted.  This is accomplished using a redis ordered set.  By using the timestamp in milliseconds as a scoring mechanism, the set orders itself in the desired way.  

A thing worth noting is that an additional time stamp was added for the `received` time of the record.  The plan, in the future, would be to leverage this timestamp in the case of a "tie" between two payers with the same `timestampMS`.  Redis allows the same score to exist, but the values of those strings in the set _must_ be different, otherwise we violate the definition of a set. So, we'd add an extra step to `zrange paymentKey 0 0` and take the timestampMS value from that, and then `zrange` with `BYSCORE` set and use the `timestampMS` as the upper and lower bound. We can then leverage the `receivedTimestamp` to break the tie.  If those values are equal, then some decision would need to be made on breaking the tie, again.  Likely just taking the first value in the set, in that case.